### PR TITLE
feat: auto generate swagger doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ install:
 	$(COMPOSE) run --rm backend npm install
 	$(COMPOSE) run --rm frontend npm install
 
+# generate swagger documentation file using swagger-autogen
+# runs in the host environment so you don't need to rebuild the image
+# (but if you do run it inside the container you must rebuild after changing package.json)
+docs:
+	cd backend && npm install && npm run docs:generate
+
 # Generate and apply initial migration on host (call this only once when starting a new project)
 migrate-init:
 	cd backend && npx prisma migrate dev --name init

--- a/README.md
+++ b/README.md
@@ -139,7 +139,23 @@ npm run dev
 
 Then open the dashboard at `http://localhost:3000`.
 
-> **API docs**: While the backend is running you can view the automatically generated Swagger documentation at `http://localhost:4000/docs`.
+> **API docs**: While the backend is running you can view the Swagger UI at `http://localhost:4000/docs/`.
+>
+> To regenerate the raw OpenAPI specification (used by the UI), run:
+>
+> ```bash
+> make docs      # invokes `npm run docs:generate` inside the backend
+> ```
+>
+> This uses [swagger-autogen](https://www.npmjs.com/package/swagger-autogen) to
+> scan your route files and output `backend/src/docs/swagger-output.json`.
+>
+> _Tip_: run `make docs` after adding or changing any endpoints so the
+> specification stays in sync.
+>
+> You do **not** need to write any JSDoc comments – the autogen tool infers paths,
+> parameters and responses automatically. Manual comments are still fine for
+> adding descriptions or examples.
 
 ---
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .env
 
 /generated/prisma
+
+# auto-generated swagger spec
+src/docs/swagger-output.json

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,7 @@
         "@types/swagger-jsdoc": "^6.0.2",
         "@types/swagger-ui-express": "^4.1.3",
         "prisma": "^7.4.2",
+        "swagger-autogen": "^2.22.0",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
@@ -1075,6 +1076,16 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -1792,6 +1803,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -2986,6 +3010,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/swagger-jsdoc": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
+    "docs:generate": "ts-node --transpile-only scripts/generate-swagger.ts",
     "start": "node dist/src/index.js",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
@@ -38,6 +39,7 @@
     "@types/pg": "^8.10.3",
     "@types/swagger-jsdoc": "^6.0.2",
     "@types/swagger-ui-express": "^4.1.3",
+    "swagger-autogen": "^2.22.0",
     "prisma": "^7.4.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3"

--- a/backend/scripts/generate-swagger.ts
+++ b/backend/scripts/generate-swagger.ts
@@ -1,0 +1,27 @@
+import swaggerAutogen from "swagger-autogen";
+import path from "path";
+
+const outputFile = path.join(__dirname, "../src/docs/swagger-output.json");
+const endpointsFiles = [
+    path.join(__dirname, "../src/index.ts"),
+    path.join(__dirname, "../src/modules/**/*.ts"),
+];
+
+const doc = {
+    info: {
+        title: "BrandqoAI Backend API",
+        description:
+            "Automatically generated API documentation for BrandqoAI backend",
+    },
+    host: `localhost:4000`,
+    schemes: ["http"],
+};
+
+(async () => {
+    await swaggerAutogen({ openapi: "3.0.0", language: "en" })(
+        outputFile,
+        endpointsFiles,
+        doc
+    );
+    console.log("Swagger spec generated at", outputFile);
+})();

--- a/backend/src/docs/swagger.ts
+++ b/backend/src/docs/swagger.ts
@@ -1,4 +1,5 @@
 import swaggerJsdoc, { type Options } from "swagger-jsdoc";
+import fs from "fs";
 import path from "path";
 import { env } from "../config/env";
 
@@ -32,5 +33,9 @@ const options: Options = {
   ],
 };
 
-export const swaggerSpec = swaggerJsdoc(options);
+const generatedPath = path.join(__dirname, "swagger-output.json");
+
+export const swaggerSpec = fs.existsSync(generatedPath)
+  ? JSON.parse(fs.readFileSync(generatedPath, "utf-8"))
+  : swaggerJsdoc(options);
 

--- a/backend/src/modules/auth/authRoutes.ts
+++ b/backend/src/modules/auth/authRoutes.ts
@@ -2,94 +2,9 @@ import { Router } from "express";
 import { registerHandler, loginHandler, meHandler } from "./authController";
 import { requireAuth } from "./authMiddleware";
 
-/**
- * @swagger
- * tags:
- *   name: Auth
- *   description: Authentication operations (register, login, profile)
- */
 export const authRouter = Router();
 
-/**
- * @swagger
- * /api/auth/register:
- *   post:
- *     summary: Register a new user
- *     tags: [Auth]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - name
- *               - email
- *               - password
- *             properties:
- *               name:
- *                 type: string
- *               email:
- *                 type: string
- *                 format: email
- *               password:
- *                 type: string
- *                 format: password
- *     responses:
- *       201:
- *         description: Created successfully with JWT token
- *       400:
- *         description: Invalid input
- *       409:
- *         description: Email already registered
- */
 authRouter.post("/register", registerHandler);
-
-/**
- * @swagger
- * /api/auth/login:
- *   post:
- *     summary: Log in a user
- *     tags: [Auth]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - email
- *               - password
- *             properties:
- *               email:
- *                 type: string
- *                 format: email
- *               password:
- *                 type: string
- *                 format: password
- *     responses:
- *       200:
- *         description: Authenticated successfully with JWT token
- *       400:
- *         description: Invalid input
- *       401:
- *         description: Invalid credentials
- */
 authRouter.post("/login", loginHandler);
-
-/**
- * @swagger
- * /api/auth/me:
- *   get:
- *     summary: Get current authenticated user's profile
- *     tags: [Auth]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: User profile returned
- *       401:
- *         description: Unauthenticated
- */
 authRouter.get("/me", requireAuth, meHandler);
 


### PR DESCRIPTION
## Summary

- What does this PR change? This PR makes swagger doc to be autogenerated by running "make docs"
- Why is it useful for BrandqoAI and creators?

## Related Issues

- Closes #<issue-number> (if applicable)

## Changes

- [X] Backend
  - [X] APIs / routes
  - [ ] Workers / scheduling
  - [ ] Data models / migrations
- [ ] Frontend
  - [ ] Pages / components
  - [ ] State / data fetching
  - [ ] Styles / UX
- [X] Documentation

## Testing

Describe how you tested this change:

- [ ] `backend`: `npm test` / `npm run dev` and manual verification
- [ ] `frontend`: `npm test` / `npm run dev` and manual verification
- [ ] Other:

## Screenshots / Demos (Optional)

If this changes UI or flows, add screenshots, recordings, or notes here.

