### PR TITLE
feat: harden Claude provider integration for content generation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,9 +17,11 @@ AI_PROVIDER=mistral
 # Required if AI_PROVIDER=mistral
 TOGETHER_API_KEY=your-together-ai-api-key
 
-# Claude Sonnet via Anthropic (~$0.003 per 1K tokens input)
+# Claude Sonnet via Anthropic
 # Required if AI_PROVIDER=claude
 ANTHROPIC_API_KEY=your-anthropic-api-key
+# Optional: override the default Claude model if needed
+ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # Stable Diffusion image generation (optional, used for image prompts)
 REPLICATE_API_KEY=your-replicate-api-key

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -32,6 +32,7 @@ export const env = {
   whatsappPhoneNumberId: process.env.WHATSAPP_PHONE_NUMBER_ID,
   whatsappAccessToken: process.env.WHATSAPP_ACCESS_TOKEN,
   anthropicApiKey: getApiKey("ANTHROPIC_API_KEY", aiProvider, "claude"),
+  anthropicModel: process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6",
   replicateApiKey: process.env.REPLICATE_API_KEY,
   togetherApiKey: getApiKey("TOGETHER_API_KEY", aiProvider, "mistral") as string,
 };

--- a/backend/src/modules/ai/claude.ts
+++ b/backend/src/modules/ai/claude.ts
@@ -2,42 +2,103 @@ import Anthropic from "@anthropic-ai/sdk";
 import { env } from "../../config/env";
 
 const client = new Anthropic({
-    apiKey: env.anthropicApiKey,
+  apiKey: env.anthropicApiKey,
 });
 
-export const generateCaption = async (prompt: string): Promise<string> => {
-    const message = await client.messages.create({
-        model: "claude-3-5-sonnet-20241022",
-        max_tokens: 1024,
-        messages: [
-            {
-                role: "user",
-                content: prompt,
-            },
-        ],
-    });
+const BASE_SYSTEM_PROMPT = "You are an API generation engine inside BrandqoAI. Return concise outputs that follow the requested format exactly. Do not add introductions, explanations, markdown, bullet lists, or commentary unless explicitly requested.";
 
-    const textContent = message.content.find((block) => block.type === "text");
-    if (!textContent || textContent.type !== "text") {
-        throw new Error("No text response from Claude");
-    }
+const extractText = (message: { content: Array<{ type: string; text?: string }> }): string => {
+  const textContent = message.content.find((block: { type: string; text?: string }) => block.type === "text");
+  if (!textContent || textContent.type !== "text" || !textContent.text) {
+    throw new Error("No text response from Claude");
+  }
 
-    return textContent.text;
+  return textContent.text.trim();
 };
 
-export const generateImagePrompt = async (
-    brandContext: string,
-    contentTopic: string
-): Promise<string> => {
-    const prompt = `You are a creative director for social media content. Given the brand context and topic, generate a detailed, vivid image prompt that would work well for Stable Diffusion. The prompt should be specific, visual, and evoke the brand's tone.
+const createMessage = async (prompt: string, system = BASE_SYSTEM_PROMPT): Promise<string> => {
+  const message = await client.messages.create({
+    model: env.anthropicModel,
+    max_tokens: 1024,
+    temperature: 0.2,
+    system,
+    messages: [
+      {
+        role: "user",
+        content: prompt,
+      },
+    ],
+  });
 
-Brand Context:
-${brandContext}
+  return extractText(message);
+};
 
-Topic:
-${contentTopic}
+const tryExtractJsonSubstring = (raw: string): string | null => {
+  const trimmed = raw.trim();
 
-Generate only the image prompt, nothing else. Make it detailed and specific for a text-to-image AI.`;
+  if (trimmed.startsWith("```")) {
+    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (fenced?.[1]) {
+      return fenced[1].trim();
+    }
+  }
 
-    return generateCaption(prompt);
+  for (let start = 0; start < trimmed.length; start++) {
+    if (trimmed[start] !== "[" && trimmed[start] !== "{") {
+      continue;
+    }
+
+    for (let end = trimmed.length - 1; end > start; end--) {
+      const candidate = trimmed.slice(start, end + 1);
+      try {
+        JSON.parse(candidate);
+        return candidate;
+      } catch {
+        // keep scanning
+      }
+    }
+  }
+
+  return null;
+};
+
+export const generateText = async (prompt: string): Promise<string> => {
+  return createMessage(prompt);
+};
+
+export const generateJson = async (prompt: string, options?: { maxRetries?: number }): Promise<string> => {
+  const maxRetries = options?.maxRetries ?? 3;
+  let lastRaw = "";
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const retryInstruction = attempt === 1
+      ? ""
+      : `\n\nIMPORTANT RETRY ${attempt}: Your previous response was not valid JSON. Return ONLY valid JSON. No prose. No markdown. No code fences.`;
+
+    const raw = await createMessage(
+      `${prompt}${retryInstruction}`,
+      `${BASE_SYSTEM_PROMPT} When JSON is requested, output valid JSON only.`,
+    );
+    lastRaw = raw;
+
+    const candidate = tryExtractJsonSubstring(raw) ?? raw.trim();
+    try {
+      JSON.parse(candidate);
+      return candidate;
+    } catch {
+      // retry
+    }
+  }
+
+  throw new Error(`Claude did not return valid JSON after ${maxRetries} attempts: ${lastRaw.slice(0, 300)}`);
+};
+
+export const generateCaption = async (_brandContext: string, userPrompt: string): Promise<string> => {
+  return generateText(userPrompt);
+};
+
+export const generateImagePrompt = async (brandContext: string, contentTopic: string): Promise<string> => {
+  const prompt = `You are a creative director for social media content. Given the brand context and topic, generate a detailed, vivid image prompt that would work well for Stable Diffusion. The prompt should be specific, visual, and evoke the brand's tone.\n\nBrand Context:\n${brandContext}\n\nTopic:\n${contentTopic}\n\nGenerate only the image prompt, nothing else. Make it detailed and specific for a text-to-image AI.`;
+
+  return generateText(prompt);
 };

--- a/backend/src/modules/ai/mistral.ts
+++ b/backend/src/modules/ai/mistral.ts
@@ -1,39 +1,53 @@
 import { env } from "../../config/env";
 
-interface TogetherResponse {
-    choices: Array<{
-        text: string;
+interface TogetherChatResponse {
+    choices?: Array<{
+        message?: {
+            content?: string;
+        };
     }>;
+    error?: {
+        message?: string;
+        code?: string;
+    };
 }
 
+const TOGETHER_MODEL = "deepseek-ai/DeepSeek-V3";
+
 export const generateCaption = async (prompt: string): Promise<string> => {
-    const response = await fetch("https://api.together.xyz/v1/completions", {
+    const response = await fetch("https://api.together.xyz/v1/chat/completions", {
         method: "POST",
         headers: {
             "Authorization": `Bearer ${env.togetherApiKey}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify({
-            model: "mistralai/Mistral-7B-Instruct-v0.2",
-            prompt: prompt,
+            model: TOGETHER_MODEL,
+            messages: [
+                {
+                    role: "user",
+                    content: prompt,
+                },
+            ],
             max_tokens: 1024,
             temperature: 0.7,
             top_p: 0.9,
-            top_k: 50,
         }),
     });
 
+    const data = await response.json() as TogetherChatResponse;
+
     if (!response.ok) {
-        throw new Error(`Together AI API error: ${response.status} ${response.statusText}`);
+        const details = data?.error?.message ? ` - ${data.error.message}` : "";
+        throw new Error(`Together AI API error: ${response.status} ${response.statusText}${details}`);
     }
 
-    const data = await response.json() as TogetherResponse;
-
-    if (!data.choices || data.choices.length === 0) {
-        throw new Error("No response from Mistral");
+    const content = data.choices?.[0]?.message?.content?.trim();
+    if (!content) {
+        throw new Error(`No response from Together model ${TOGETHER_MODEL}`);
     }
 
-    return data.choices[0].text.trim();
+    return content;
 };
 
 export const generateImagePrompt = async (

--- a/backend/src/modules/ai/provider.ts
+++ b/backend/src/modules/ai/provider.ts
@@ -3,16 +3,17 @@ import * as claude from "./claude";
 import * as mistral from "./mistral";
 
 export interface AIProvider {
-    generateCaption(brandContext: string, userPrompt: string): Promise<string>;
-    generateImagePrompt(caption: string, brandContext: string): Promise<string>;
+  generateCaption(brandContext: string, userPrompt: string): Promise<string>;
+  generateImagePrompt(brandContext: string, contentTopic: string): Promise<string>;
+  generateJson?(prompt: string, options?: { maxRetries?: number }): Promise<string>;
 }
 
 export const createProvider = (): AIProvider => {
-    if (env.aiProvider === "claude") {
-        return claude;
-    } else if (env.aiProvider === "mistral") {
-        return mistral;
-    } else {
-        throw new Error(`Unknown AI provider: ${env.aiProvider}`);
-    }
+  if (env.aiProvider === "claude") {
+    return claude;
+  } else if (env.aiProvider === "mistral") {
+    return mistral;
+  } else {
+    throw new Error(`Unknown AI provider: ${env.aiProvider}`);
+  }
 };

--- a/backend/src/modules/content/contentService.ts
+++ b/backend/src/modules/content/contentService.ts
@@ -12,6 +12,7 @@ interface GeneratedPostTemplate {
   imagePrompt: string;
 }
 
+
 interface GeneratedCalendarEntry {
   date?: string;
   topic: string;
@@ -124,11 +125,66 @@ const parseScheduledAt = (value: string | undefined, fallback: Date): Date => {
   return parsed;
 };
 
+const extractJsonPayload = (raw: string): unknown => {
+  const trimmed = raw.trim();
+
+  const tryParse = (value: string): unknown | null => {
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      return null;
+    }
+  };
+
+  if (trimmed.startsWith("```")) {
+    const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (fenced?.[1]) {
+      const parsed = tryParse(fenced[1].trim());
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+  }
+
+  for (let start = 0; start < trimmed.length; start++) {
+    if (trimmed[start] !== "[" && trimmed[start] !== "{") {
+      continue;
+    }
+
+    for (let end = trimmed.length - 1; end > start; end--) {
+      const candidate = trimmed.slice(start, end + 1);
+      const parsed = tryParse(candidate);
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+  }
+
+  throw new Error(`Model did not return parseable JSON: ${trimmed.slice(0, 200)}`);
+};
+
+const extractStructuredCalendarPayload = (raw: string): Array<Record<string, unknown>> => {
+  const parsed = extractJsonPayload(raw);
+  if (Array.isArray(parsed)) {
+    return parsed as Array<Record<string, unknown>>;
+  }
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "entries" in parsed &&
+    Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    return (parsed as { entries: Array<Record<string, unknown>> }).entries;
+  }
+
+  throw new Error(`Model did not return a calendar array payload`);
+};
+
 const normalizeCalendarResponse = (
   raw: string,
   postingFrequency: string | null | undefined
 ): GeneratedCalendarEntry[] => {
-  const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
+  const parsed = extractStructuredCalendarPayload(raw);
 
   return parsed
     .filter((entry) => typeof entry.topic === "string" && typeof entry.caption === "string")
@@ -208,22 +264,36 @@ export const generateTestContentForBrand = async (
   try {
     const provider = createProvider();
 
-    const captionPrompt = `You are a social media copywriter for a creator. Generate 2 different Instagram captions based on the following:
+    const captionPrompt = `Generate exactly 2 Instagram caption options for this brand and topic.
 
 ${brandContext}
 
 Topic/Request: ${params.userPrompt}
 
-Generate exactly 2 captions. Separate them with "---". Each caption should be engaging, authentic to the brand, and end with a call-to-action or relevant emoji. Keep each under 150 characters for the hook.`;
+CRITICAL OUTPUT RULES:
+- Return ONLY valid JSON.
+- Do NOT include prose, explanations, markdown, bullets, numbering, headings, or code fences.
+- Start with [ and end with ].
+- Return exactly 2 objects.
+- Each object must have only one field: "caption".
+- Each caption should be engaging, authentic to the brand, and end with a call-to-action or relevant emoji.`;
 
-    const captionsText = await provider.generateCaption(brandContext, captionPrompt);
-    const captions = captionsText.split("---").map((c) => c.trim());
+    const captionsText = provider.generateJson
+      ? await provider.generateJson(captionPrompt, { maxRetries: 4 })
+      : await provider.generateCaption(brandContext, captionPrompt);
+    const parsedCaptions = extractJsonPayload(captionsText);
+    const captions = Array.isArray(parsedCaptions)
+      ? (parsedCaptions as Array<Record<string, unknown>>)
+          .map((item) => (typeof item.caption === "string" ? item.caption.trim() : ""))
+          .filter(Boolean)
+          .slice(0, 2)
+      : [];
 
     const ideas: GeneratedPostTemplate[] = [];
 
     for (const caption of captions) {
       if (caption) {
-        const imagePromptText = await provider.generateImagePrompt(caption, brandContext);
+        const imagePromptText = await provider.generateImagePrompt(brandContext, caption);
 
         ideas.push({
           caption,
@@ -285,21 +355,38 @@ Posting frequency: ${brand.preferences.postingFrequency ?? "weekly"}
 Posts needed across the next 30 days: ${postsNeeded}
 Timezone: ${brand.user.timezone ?? "UTC"}
 
-Return ONLY valid JSON as an array. Each item must contain:
+CRITICAL OUTPUT RULES:
+- Return ONLY valid JSON.
+- Do NOT include any prose, preface, explanation, markdown, code fences, or labels.
+- Start the first character with [ and end the final character with ].
+- The response must be a JSON array with exactly ${postsNeeded} objects.
+
+Each object must contain:
 - topic
 - caption
 - platforms (array containing one or more of INSTAGRAM, FACEBOOK, TWITTER)
 - scheduledAt (ISO datetime) OR date (YYYY-MM-DD)
+
+Example format:
+[
+  {
+    "topic": "Behind the scenes of building Oracus",
+    "caption": "A quick look behind the scenes as we build smarter workflows for creators.",
+    "platforms": ["INSTAGRAM"],
+    "date": "2026-03-28"
+  }
+]
 
 Rules:
 - create exactly ${postsNeeded} items
 - spread posts naturally across the next 30 days
 - make captions beginner-friendly and brand-aware
 - keep captions under 2200 characters
-- prefer INSTAGRAM unless another platform clearly fits
-- do not include markdown fences or commentary`;
+- prefer INSTAGRAM unless another platform clearly fits`;
 
-      const raw = await provider.generateCaption(brandContext, prompt);
+      const raw = provider.generateJson
+        ? await provider.generateJson(prompt, { maxRetries: 4 })
+        : await provider.generateCaption(brandContext, prompt);
       const entries = normalizeCalendarResponse(raw, brand.preferences.postingFrequency).slice(0, postsNeeded);
 
       if (entries.length !== postsNeeded) {


### PR DESCRIPTION
## Summary
- make the Anthropic model configurable with a working Claude 4 default
- harden the Claude provider with strict JSON generation + retry handling
- update content/calendar generation to use structured JSON parsing when supported
- align AI provider method signatures and modernize the Together chat completion path
- document Claude model configuration in `.env.example`

## Why
BrandqoAI had Claude support in place, but it was pinned to an outdated model path and relied on brittle free-text formatting for generation. This makes Claude-backed content/calendar generation more reliable and easier to configure.

## Validation
- backend build passes
- direct Claude JSON generation returns parseable JSON
- direct built-service content generation returns usable captions + image prompts
- direct built-service calendar generation returns structured scheduled entries

Closes #34
