### PR TITLE
fix: clarify social account onboarding handoff

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -24,6 +24,7 @@ const getApiKey = (key: string, provider: string, expectedProvider: string): str
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
+  appUrl: process.env.APP_URL,
   databaseUrl: getEnv("DATABASE_URL"),
   jwtSecret: getEnv("JWT_SECRET"),
   corsOrigin: process.env.CORS_ORIGIN ?? "*",

--- a/backend/src/modules/conversation/whatsappConversationService.ts
+++ b/backend/src/modules/conversation/whatsappConversationService.ts
@@ -1,4 +1,5 @@
 import { prisma, Prisma } from "../../db/client";
+import { env } from "../../config/env";
 import { generateMonthlyCalendarForBrand, generateTestContentForBrand } from "../content/contentService";
 
 type ConversationStep =
@@ -257,12 +258,21 @@ const onboardingCompletionMessage = (
   ].join("\n");
 };
 
+const getDashboardUrl = () => env.appUrl ?? env.corsOrigin?.replace(/\/$/, "") ?? null;
+
 const socialConnectionRequiredMessage = () => {
+  const dashboardUrl = getDashboardUrl();
+
   return [
     "Your brand profile is saved, but onboarding cannot finish yet.",
     "",
-    "Please connect at least one social account first, then message me again and I’ll continue with your posting frequency and approval settings.",
-  ].join("\n");
+    "Please connect at least one social account first on the web dashboard, then message me again and I’ll continue with your posting frequency and approval settings.",
+    dashboardUrl ? `Dashboard: ${dashboardUrl}/dashboard` : null,
+    "",
+    "After you connect a social account, come back here and send any message to continue.",
+  ]
+    .filter(Boolean)
+    .join("\n");
 };
 
 const getStepPrompt = async (state: {

--- a/frontend/app/(auth)/dashboard/page.tsx
+++ b/frontend/app/(auth)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { CalendarDays, CheckCircle2, Clock3, Layers3, Loader2, LogOut, Moon, Pencil, Sparkles, Sun, Trash2 } from "lucide-react";
+import { CalendarDays, CheckCircle2, Clock3, Layers3, Link as LinkIcon, Loader2, LogOut, Moon, Pencil, Sparkles, Sun, Trash2 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useState, useEffect, useMemo } from "react";
 import { useAuthGuard } from "@/components/hooks/useAuthGuard";
@@ -199,6 +199,27 @@ export default function DashboardPage() {
             value={data?.summary.upcomingCount ?? 0}
             subtitle="Posts still waiting to be published."
           />
+        </section>
+
+        <section className="card p-6 border border-dashed border-border">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="flex items-center gap-2 text-foreground">
+                <LinkIcon className="h-5 w-5 text-primary" />
+                <h2 className="text-lg font-heading font-semibold">Social account connection</h2>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                WhatsApp onboarding expects at least one connected social account before it can finish your posting frequency and approval setup.
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                For now, the actual social account connection flow is still being implemented. If WhatsApp told you to connect an account here, that handoff is now clearer, but the full connect flow is not live yet.
+              </p>
+            </div>
+            <Button variant="outline" className="gap-2" disabled>
+              <LinkIcon className="h-4 w-4" />
+              Connect social account (coming soon)
+            </Button>
+          </div>
         </section>
 
         <section className="grid gap-6 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- add a concrete dashboard link to the WhatsApp social-account-required onboarding message
- tell users to return to WhatsApp after connecting an account
- add a dashboard notice clarifying that the social account connection flow is not fully implemented yet

## Testing
- npm run build (backend)

Closes #40