### PR TITLE
ci: add GitHub Actions pipeline for Railway deploys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,135 @@
+name: CI/CD
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  backend-ci:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/placeholder
+
+      - name: Build backend
+        run: npm run build
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/placeholder
+          JWT_SECRET: ci-placeholder-secret
+          AI_PROVIDER: mistral
+          TOGETHER_API_KEY: ci-placeholder-key
+
+      - name: Run backend test placeholder
+        run: npm test
+        continue-on-error: true
+
+  frontend-ci:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Lint frontend
+        run: npm run lint
+
+      - name: Build frontend
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://example.com
+
+      - name: Run frontend test placeholder
+        run: npm test
+        continue-on-error: true
+
+  dependency-scan:
+    name: Dependency scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run npm audit for backend
+        run: npm audit --audit-level=high
+        working-directory: backend
+
+      - name: Run npm audit for frontend
+        run: npm audit --audit-level=high
+        working-directory: frontend
+
+  deploy-backend:
+    name: Deploy backend to Railway
+    runs-on: ubuntu-latest
+    needs:
+      - backend-ci
+      - frontend-ci
+      - dependency-scan
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy backend service
+        run: railway up backend --service backend --path-as-root --ci
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+
+  deploy-frontend:
+    name: Deploy frontend to Railway
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-backend
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy frontend service
+        run: railway up frontend --service frontend --path-as-root --ci
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,15 @@ If you’re proposing a larger feature, outline:
 
 ## Pull Request Process
 
+### CI/CD Pipeline
+
+BrandqoAI uses GitHub Actions for continuous integration and Railway deployment automation.
+
+- Pull requests targeting `develop` and `main` run automated checks for backend build health, frontend lint/build, and dependency scanning.
+- Pushes to `main` trigger automated Railway deployments for the `backend` and `frontend` services after CI passes.
+- Railway deployment automation expects GitHub repository secrets named `RAILWAY_TOKEN` and `RAILWAY_PROJECT_ID` to be configured.
+- If a workflow fails, treat it as a merge blocker until the failure is understood and fixed.
+
 ### Before Opening a PR
 
 - [ ] Your branch is up to date with `develop`


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for backend/frontend CI on pull requests
- add dependency scanning with npm audit for backend and frontend
- add Railway deployment jobs that run automatically on pushes to main
- document the CI/CD pipeline and required GitHub secrets in Contributing.md

## Notes
- Automatic Railway deployment requires GitHub repository secrets `RAILWAY_TOKEN` and `RAILWAY_PROJECT_ID` to be configured in the main repository before deploy jobs can succeed.
- The project currently has no real automated test suites, so the workflow validates build/lint health and includes placeholder test steps.

Closes #18
