### PR TITLE
feat: add WhatsApp magic link dashboard handoff

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -25,6 +25,8 @@ export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   appUrl: process.env.APP_URL,
+  backendPublicUrl: process.env.BACKEND_PUBLIC_URL,
+  magicLinkSecret: process.env.MAGIC_LINK_SECRET ?? process.env.JWT_SECRET,
   databaseUrl: getEnv("DATABASE_URL"),
   jwtSecret: getEnv("JWT_SECRET"),
   corsOrigin: process.env.CORS_ORIGIN ?? "*",

--- a/backend/src/modules/auth/authController.ts
+++ b/backend/src/modules/auth/authController.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "../../db/client";
 import { env } from "../../config/env";
 import type { AuthenticatedRequest } from "./authMiddleware";
+import { verifyWhatsAppMagicLinkToken } from "./magicLink";
 
 const registerSchema = z.object({
   name: z.string().min(1),
@@ -28,6 +29,18 @@ const verifyPassword = async (password: string, hash: string) => {
 
 const createToken = (userId: string) => {
   return jwt.sign({ userId }, env.jwtSecret, { expiresIn: "7d" });
+};
+
+const setAuthCookie = (res: Response, token: string) => {
+  const isProduction = env.nodeEnv === "production";
+
+  res.cookie("token", token, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: isProduction ? "none" : "lax",
+    maxAge: 7 * 24 * 60 * 60 * 1000,
+    path: "/",
+  });
 };
 
 export const registerHandler = async (req: Request, res: Response) => {
@@ -91,16 +104,7 @@ export const loginHandler = async (req: Request, res: Response) => {
     return res.status(401).json({ message: "Something went wrong" });
   }
 
-  const isProduction = env.nodeEnv === "production";
-
-  // Set the cookie directly in the browser
-  res.cookie("token", token, {
-    httpOnly: true,
-    secure: isProduction,
-    sameSite: isProduction ? "none" : "lax",
-    maxAge: 7 * 24 * 60 * 60 * 1000,
-    path: "/",
-  });
+  setAuthCookie(res, token);
 
   return res.json({
     message: "Login successful",
@@ -127,6 +131,33 @@ export const logoutHandler = (req: Request, res: Response) => {
   return res.json({ message: "Logged out successfully" });
 };
 
+
+export const consumeWhatsAppMagicLinkHandler = async (req: Request, res: Response) => {
+  try {
+    const token = typeof req.query.token === "string" ? req.query.token : null;
+    if (!token) {
+      return res.status(400).json({ message: "Missing magic link token" });
+    }
+
+    const payload = verifyWhatsAppMagicLinkToken(token);
+    if (payload.purpose !== "whatsapp-dashboard-handoff") {
+      return res.status(400).json({ message: "Invalid magic link" });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: payload.userId } });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const authToken = createToken(user.id);
+    setAuthCookie(res, authToken);
+
+    const destination = env.appUrl ? `${env.appUrl.replace(/\/$/, "")}/dashboard` : "/dashboard";
+    return res.redirect(destination);
+  } catch {
+    return res.status(401).json({ message: "Invalid or expired magic link" });
+  }
+};
 
 export const meHandler = async (req: AuthenticatedRequest, res: Response) => {
   if (!req.user) {

--- a/backend/src/modules/auth/authRoutes.ts
+++ b/backend/src/modules/auth/authRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { registerHandler, loginHandler, meHandler, logoutHandler } from "./authController";
+import { registerHandler, loginHandler, meHandler, logoutHandler, consumeWhatsAppMagicLinkHandler } from "./authController";
 import { requireAuth } from "./authMiddleware";
 
 export const authRouter = Router();
@@ -116,7 +116,7 @@ authRouter.post("/login", loginHandler);
  *         description: Unauthorized (if session was already invalid)
  */
 authRouter.post("/logout", logoutHandler);
-
+authRouter.get("/whatsapp-link-login", consumeWhatsAppMagicLinkHandler);
 
 /**
  * @swagger

--- a/backend/src/modules/auth/magicLink.ts
+++ b/backend/src/modules/auth/magicLink.ts
@@ -1,0 +1,42 @@
+import jwt from "jsonwebtoken";
+import { env } from "../../config/env";
+
+const MAGIC_LINK_EXPIRY = "15m";
+const MAGIC_LINK_SECRET = env.magicLinkSecret ?? env.jwtSecret;
+
+interface MagicLinkPayload {
+  userId: string;
+  whatsappPhone: string;
+  purpose: "whatsapp-dashboard-handoff";
+}
+
+export const createWhatsAppMagicLinkToken = (params: {
+  userId: string;
+  whatsappPhone: string;
+}) => {
+  const payload: MagicLinkPayload = {
+    userId: params.userId,
+    whatsappPhone: params.whatsappPhone,
+    purpose: "whatsapp-dashboard-handoff",
+  };
+
+  return jwt.sign(payload, MAGIC_LINK_SECRET, { expiresIn: MAGIC_LINK_EXPIRY });
+};
+
+export const verifyWhatsAppMagicLinkToken = (token: string): MagicLinkPayload => {
+  const decoded = jwt.verify(token, MAGIC_LINK_SECRET) as jwt.JwtPayload;
+
+  if (
+    typeof decoded.userId !== "string" ||
+    typeof decoded.whatsappPhone !== "string" ||
+    decoded.purpose !== "whatsapp-dashboard-handoff"
+  ) {
+    throw new Error("Invalid magic link payload");
+  }
+
+  return {
+    userId: decoded.userId,
+    whatsappPhone: decoded.whatsappPhone,
+    purpose: "whatsapp-dashboard-handoff",
+  };
+};

--- a/backend/src/modules/conversation/whatsappConversationService.ts
+++ b/backend/src/modules/conversation/whatsappConversationService.ts
@@ -1,5 +1,6 @@
 import { prisma, Prisma } from "../../db/client";
 import { env } from "../../config/env";
+import { createWhatsAppMagicLinkToken } from "../auth/magicLink";
 import { generateMonthlyCalendarForBrand, generateTestContentForBrand } from "../content/contentService";
 
 type ConversationStep =
@@ -259,15 +260,34 @@ const onboardingCompletionMessage = (
 };
 
 const getDashboardUrl = () => env.appUrl ?? env.corsOrigin?.replace(/\/$/, "") ?? null;
+const getBackendPublicUrl = () => env.backendPublicUrl?.replace(/\/$/, "") ?? null;
 
-const socialConnectionRequiredMessage = () => {
+const createWhatsAppMagicDashboardLink = (params: { userId: string; fromPhone: string }) => {
+  const backendPublicUrl = getBackendPublicUrl();
+  if (!backendPublicUrl) {
+    return null;
+  }
+
+  const token = createWhatsAppMagicLinkToken({
+    userId: params.userId,
+    whatsappPhone: params.fromPhone,
+  });
+
+  return `${backendPublicUrl}/api/auth/whatsapp-link-login?token=${encodeURIComponent(token)}`;
+};
+
+const socialConnectionRequiredMessage = (params?: { userId?: string | null; fromPhone?: string }) => {
+  const magicLink =
+    params?.userId && params?.fromPhone
+      ? createWhatsAppMagicDashboardLink({ userId: params.userId, fromPhone: params.fromPhone })
+      : null;
   const dashboardUrl = getDashboardUrl();
 
   return [
     "Your brand profile is saved, but onboarding cannot finish yet.",
     "",
     "Please connect at least one social account first on the web dashboard, then message me again and I’ll continue with your posting frequency and approval settings.",
-    dashboardUrl ? `Dashboard: ${dashboardUrl}/dashboard` : null,
+    magicLink ? `Secure sign-in link: ${magicLink}` : dashboardUrl ? `Dashboard: ${dashboardUrl}/dashboard` : null,
     "",
     "After you connect a social account, come back here and send any message to continue.",
   ]
@@ -302,7 +322,7 @@ const getStepPrompt = async (state: {
     case "ASK_APPROVAL_MODE":
       return promptForApprovalMode();
     case "WAIT_FOR_SOCIAL_CONNECTION":
-      return socialConnectionRequiredMessage();
+      return socialConnectionRequiredMessage({ userId: state.userId });
     case "WELCOME":
     case "READY":
     default:
@@ -573,7 +593,7 @@ export const handleIncomingWhatsAppText = async (params: HandleIncomingMessagePa
         await touchConversation(state.id, {
           currentStep: "WAIT_FOR_SOCIAL_CONNECTION",
         });
-        return socialConnectionRequiredMessage();
+        return socialConnectionRequiredMessage({ userId: latestState?.userId, fromPhone });
       }
 
       await touchConversation(state.id, {
@@ -589,7 +609,7 @@ export const handleIncomingWhatsAppText = async (params: HandleIncomingMessagePa
 
       if (!userHasSocialAccount) {
         await touchConversation(state.id);
-        return socialConnectionRequiredMessage();
+        return socialConnectionRequiredMessage({ userId: latestState?.userId, fromPhone });
       }
 
       await touchConversation(state.id, { currentStep: "ASK_POSTING_FREQUENCY" });
@@ -642,7 +662,7 @@ export const handleIncomingWhatsAppText = async (params: HandleIncomingMessagePa
         await touchConversation(state.id, {
           currentStep: "WAIT_FOR_SOCIAL_CONNECTION",
         });
-        return socialConnectionRequiredMessage();
+        return socialConnectionRequiredMessage({ userId: latestState?.userId, fromPhone });
       }
 
       const brand = await prisma.brandProfile.findUnique({ where: { id: brandId } });


### PR DESCRIPTION
## Summary
- add a short-lived signed WhatsApp magic-link token for dashboard handoff
- add a backend auth route that consumes the token, creates the normal auth cookie, and redirects to the dashboard
- update the WhatsApp social-account gate message to send a personalized secure sign-in link instead of a generic dashboard URL
- separate frontend app URL from backend public URL so the handoff flow points at the correct service

## Testing
- npm run build (backend)

## Notes
- This enables the WhatsApp-to-dashboard auth handoff needed before real social account connection UX can work for WhatsApp-onboarded users.
- Railway/runtime config will need `APP_URL` (frontend) and `BACKEND_PUBLIC_URL` (backend) set for production.

Closes #44
