### PR TITLE
fix: remove duplicate /api prefix from frontend requests

### DIFF
--- a/frontend/app/whatsapp-login/page.tsx
+++ b/frontend/app/whatsapp-login/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 const API_BASE_URL = "/api";
-
 type Status = "loading" | "error";
 
 function WhatsAppLoginContent() {
@@ -23,7 +22,7 @@ function WhatsAppLoginContent() {
       }
 
       try {
-        const response = await fetch(`${API_BASE_URL}/api/auth/whatsapp-link-login`, {
+        const response = await fetch(`${API_BASE_URL}/auth/whatsapp-link-login`, {
           method: "POST",
           credentials: "include",
           headers: {

--- a/frontend/components/hooks/useAuthForms.ts
+++ b/frontend/components/hooks/useAuthForms.ts
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 const API_BASE_URL = "/api";
-
 export const useAuthForm = () => {
   const router = useRouter();
 
@@ -48,7 +47,7 @@ export const useAuthForm = () => {
     setLoading(true);
     try {
       const endpoint =
-        mode === "login" ? "/api/auth/login" : "/api/auth/register";
+        mode === "login" ? "/auth/login" : "/auth/register";
       const response = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -75,7 +74,7 @@ export const useAuthForm = () => {
           setFormData((prev) => ({ ...prev, password: "" })); // Clear sensitive data
         }
       } else {
-        const meResponse = await fetch(`${API_BASE_URL}/api/auth/me`, {
+        const meResponse = await fetch(`${API_BASE_URL}/auth/me`, {
           method: "GET",
           credentials: "include",
           cache: "no-store",

--- a/frontend/components/hooks/useBrandSettings.ts
+++ b/frontend/components/hooks/useBrandSettings.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const API_BASE_URL = "/api";
-
 export interface BrandSettings {
   id: string;
   brandName: string;
@@ -45,7 +44,7 @@ export const useBrandSettings = () => {
   const fetchBrands = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_BASE_URL}/api/brand`, {
+      const response = await fetch(`${API_BASE_URL}/brand`, {
         credentials: "include",
       });
 
@@ -101,7 +100,7 @@ export const useBrandSettings = () => {
       try {
         setSaving(true);
         setSuccessMessage(null);
-        const response = await fetch(`${API_BASE_URL}/api/brand/${brandId}`, {
+        const response = await fetch(`${API_BASE_URL}/brand/${brandId}`, {
           method: "PATCH",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
@@ -143,7 +142,7 @@ export const useBrandSettings = () => {
       try {
         setRegenerating(true);
         setSuccessMessage(null);
-        const response = await fetch(`${API_BASE_URL}/api/content/calendar/generate`, {
+        const response = await fetch(`${API_BASE_URL}/content/calendar/generate`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },

--- a/frontend/components/hooks/useDashboardData.ts
+++ b/frontend/components/hooks/useDashboardData.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useState } from "react";
 
 const API_BASE_URL = "/api";
-
 export interface DashboardBrand {
   id: string;
   brandName: string;
@@ -69,7 +68,7 @@ export const useDashboardData = () => {
   const fetchDashboard = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_BASE_URL}/api/content/calendar?month=${getCurrentMonth()}`, {
+      const response = await fetch(`${API_BASE_URL}/content/calendar?month=${getCurrentMonth()}`, {
         method: "GET",
         credentials: "include",
       });
@@ -95,7 +94,7 @@ export const useDashboardData = () => {
   const updateEntry = useCallback(async (entryId: string, payload: UpdateDashboardEntryInput) => {
     try {
       setPendingEntryId(entryId);
-      const response = await fetch(`${API_BASE_URL}/api/content/calendar/${entryId}`, {
+      const response = await fetch(`${API_BASE_URL}/content/calendar/${entryId}`, {
         method: "PATCH",
         credentials: "include",
         headers: {
@@ -122,7 +121,7 @@ export const useDashboardData = () => {
   const approveEntry = useCallback(async (entryId: string) => {
     try {
       setPendingEntryId(entryId);
-      const response = await fetch(`${API_BASE_URL}/api/content/calendar/${entryId}/approve`, {
+      const response = await fetch(`${API_BASE_URL}/content/calendar/${entryId}/approve`, {
         method: "POST",
         credentials: "include",
       });
@@ -145,7 +144,7 @@ export const useDashboardData = () => {
   const deleteEntry = useCallback(async (entryId: string) => {
     try {
       setPendingEntryId(entryId);
-      const response = await fetch(`${API_BASE_URL}/api/content/calendar/${entryId}`, {
+      const response = await fetch(`${API_BASE_URL}/content/calendar/${entryId}`, {
         method: "DELETE",
         credentials: "include",
       });

--- a/frontend/components/hooks/useFetchMe.ts
+++ b/frontend/components/hooks/useFetchMe.ts
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation"; // React 19 / Next 15+ standard
 
 const API_BASE_URL = "/api";
-
 interface User {
   id: string;
   name: string | null;
@@ -19,7 +18,7 @@ export const useFetchMe = () => {
   useEffect(() => {
     const fetchMe = async () => {
       try {
-        const response = await fetch(`${API_BASE_URL}/api/auth/me`, {
+        const response = await fetch(`${API_BASE_URL}/auth/me`, {
           method: "GET",
           // The browser automatically sends the secure cookie with this flag
           credentials: "include",
@@ -45,7 +44,7 @@ export const useFetchMe = () => {
 
   const handleLogout = async () => {
     try {
-      await fetch(`${API_BASE_URL}/api/auth/logout`, {
+      await fetch(`${API_BASE_URL}/auth/logout`, {
         method: "POST",
         credentials: "include",
       });

--- a/frontend/components/hooks/useSocialAccounts.ts
+++ b/frontend/components/hooks/useSocialAccounts.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const API_BASE_URL = "/api";
-
 export type SocialPlatform = "INSTAGRAM" | "FACEBOOK" | "TWITTER";
 
 export interface SocialAccount {
@@ -57,7 +56,7 @@ export const useSocialAccounts = () => {
   const fetchAccounts = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_BASE_URL}/api/social/accounts`, {
+      const response = await fetch(`${API_BASE_URL}/social/accounts`, {
         credentials: "include",
       });
 
@@ -81,7 +80,7 @@ export const useSocialAccounts = () => {
 
   const loadMetaSelectionSession = useCallback(async (session: string) => {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/social/meta/assets?session=${encodeURIComponent(session)}`, {
+      const response = await fetch(`${API_BASE_URL}/social/meta/assets?session=${encodeURIComponent(session)}`, {
         credentials: "include",
       });
 
@@ -145,7 +144,7 @@ export const useSocialAccounts = () => {
     setSubmitting(true);
     setSuccessMessage(null);
     setError(null);
-    const url = new URL(`${API_BASE_URL}/api/social/meta/connect`);
+    const url = new URL(`${window.location.origin}/social/meta/connect`);
     url.searchParams.set("platform", platform);
     url.searchParams.set("origin", "dashboard");
     url.searchParams.set("redirect", "/dashboard");
@@ -153,7 +152,7 @@ export const useSocialAccounts = () => {
   }, []);
 
   const getDisconnectImpact = useCallback(async (accountId: string) => {
-    const response = await fetch(`${API_BASE_URL}/api/social/accounts/${accountId}/impact`, {
+    const response = await fetch(`${API_BASE_URL}/social/accounts/${accountId}/impact`, {
       credentials: "include",
     });
 
@@ -171,7 +170,7 @@ export const useSocialAccounts = () => {
       try {
         setDisconnecting(true);
         setSuccessMessage(null);
-        const response = await fetch(`${API_BASE_URL}/api/social/accounts/${accountId}`, {
+        const response = await fetch(`${API_BASE_URL}/social/accounts/${accountId}`, {
           method: "DELETE",
           credentials: "include",
         });
@@ -209,7 +208,7 @@ export const useSocialAccounts = () => {
 
     try {
       setSelectionSubmitting(true);
-      const response = await fetch(`${API_BASE_URL}/api/social/meta/link`, {
+      const response = await fetch(`${API_BASE_URL}/social/meta/link`, {
         method: "POST",
         credentials: "include",
         headers: {


### PR DESCRIPTION
## Summary
- remove the duplicated `/api` prefix from frontend auth, dashboard, social-account, and WhatsApp login requests
- keep the frontend request paths aligned with the current API base strategy so production requests no longer resolve to `/api/api/...`
- preserve the existing WhatsApp handoff and dashboard flows while fixing the bad path construction

## Testing
- confirmed the failing live request path was `POST /api/api/auth/login`
- validated the affected hooks/pages now build request URLs without the extra prefix

## Notes
- PR #100 was already merged; this is the clean follow-up PR for the regression fix only.