### PR TITLE
fix: route Meta OAuth connect through frontend API proxy

### DIFF
--- a/frontend/components/hooks/useSocialAccounts.ts
+++ b/frontend/components/hooks/useSocialAccounts.ts
@@ -144,7 +144,7 @@ export const useSocialAccounts = () => {
     setSubmitting(true);
     setSuccessMessage(null);
     setError(null);
-    const url = new URL(`${window.location.origin}/social/meta/connect`);
+    const url = new URL(`${window.location.origin}/api/social/meta/connect`);
     url.searchParams.set("platform", platform);
     url.searchParams.set("origin", "dashboard");
     url.searchParams.set("redirect", "/dashboard");


### PR DESCRIPTION
## Summary
- route the Meta OAuth connect button through `/api/social/meta/connect`
- use the existing frontend API rewrite instead of sending users to a missing frontend page
- fix the 404 that happens before the Meta OAuth flow even starts

## Problem
The dashboard was redirecting users to `/social/meta/connect`, but that route does not exist in the Next frontend app. The real OAuth endpoint already exists on the backend at `/api/social/meta/connect`, and the frontend is configured to proxy `/api/*` to the backend.

## Result
Clicking connect now reaches the backend OAuth endpoint instead of landing on a frontend 404 page.